### PR TITLE
Disable out of stock items

### DIFF
--- a/Scuti/Scripts/UI/Account/CardManager.cs
+++ b/Scuti/Scripts/UI/Account/CardManager.cs
@@ -30,6 +30,9 @@ namespace Scuti.UI
         private UserCard _cachedCard = null;
 
         private List<UserCard> _cardsInformation;
+
+        public System.Action<CardDetailsForm.Model> OnCardSelected;
+
         public bool isSelectCardMode;
 
 
@@ -127,6 +130,9 @@ namespace Scuti.UI
 
         public override void Close()
         {
+            if (isSelectCardMode)
+                OnCardSelected?.Invoke(UIManager.Card.Data);
+
             isSelectCardMode = false;
             base.Close();
         }

--- a/Scuti/Scripts/UI/Store/CartPresenter.cs
+++ b/Scuti/Scripts/UI/Store/CartPresenter.cs
@@ -583,7 +583,6 @@ namespace Scuti.UI
             UIManager.CardManager.OnCardSelected += OnCreditCard;
             UIManager.Open(UIManager.CardManager);
             UIManager.Card.SetCached(_cachedCard, Data.ShippingAddress);
-            Debug.Log("Open Edit credit card");
         }
 
 
@@ -599,11 +598,8 @@ namespace Scuti.UI
         // Handlers
         //private void OnCreditCard(CardManager.Model data)
         private void OnCreditCard(CardDetailsForm.Model data)
-        {
-            Debug.Log("Load data credit card added");
-
+        {           
             TryToLoadData(true);
-
             // Search in payment method list for one with "id" that matches payment method in "data"
             /*_cachedCard = _cardsInformation.Find(f => f.Last4 == data.Card.Number);
             _cachedAddress = false;

--- a/Scuti/Scripts/UI/Store/CartPresenter.cs
+++ b/Scuti/Scripts/UI/Store/CartPresenter.cs
@@ -579,10 +579,11 @@ namespace Scuti.UI
         {
             // Opens the card manager window
             UIManager.CardManager.isSelectCardMode = true;
-            UIManager.CardManager.OnSubmit -= OnCreditCard;
-            UIManager.CardManager.OnSubmit += OnCreditCard;
+            UIManager.CardManager.OnCardSelected -= OnCreditCard;
+            UIManager.CardManager.OnCardSelected += OnCreditCard;
             UIManager.Open(UIManager.CardManager);
             UIManager.Card.SetCached(_cachedCard, Data.ShippingAddress);
+            Debug.Log("Open Edit credit card");
         }
 
 
@@ -596,15 +597,20 @@ namespace Scuti.UI
         }
 
         // Handlers
-        private void OnCreditCard(CardManager.Model data)
+        //private void OnCreditCard(CardManager.Model data)
+        private void OnCreditCard(CardDetailsForm.Model data)
         {
+            Debug.Log("Load data credit card added");
+
+            TryToLoadData(true);
+
             // Search in payment method list for one with "id" that matches payment method in "data"
-            _cachedCard = _cardsInformation.Find(f => f.Last4 == data.Card.Number);
+            /*_cachedCard = _cardsInformation.Find(f => f.Last4 == data.Card.Number);
             _cachedAddress = false;
 
             Data.Card = data.Card;
             Data.BillingAddress = data.Address;
-            RefreshText();
+            RefreshText();*/
         }
 
         private void OnShippingSubmitted(AddressForm.Model data)

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -25,7 +25,7 @@ namespace Scuti.UI {
         [Serializable]
         public class Model : Presenter.Model {
 
-            public static string DEFAULT = "Other";
+            public static string DEFAULT = "null";
 
             private List<StockModelUpdated> _stockOutModelUpdated;
             private List<StockModelUpdated> _stockIn;
@@ -65,11 +65,7 @@ namespace Scuti.UI {
                                     if (!string.IsNullOrEmpty(variant.Option3))
                                     {    
                                         thirdLabel = variant.Option3;
-                                    }
-                                    else 
-                                    {
-                                        Debug.Log("Is emty Label 3-" + variant.Option3+"--");
-                                    }
+                                    }    
                                 }
                             }
 
@@ -111,14 +107,14 @@ namespace Scuti.UI {
                             //}
                         }
 
-                        Debug.Log("Stock Before: " + _stockIn.Count);
+                        //Debug.Log("Stock Before: " + _stockIn.Count);
                         _stockIn = RemoveDuplicatedItems(_stockIn);
-                        Debug.Log("Stock After: " + _stockIn.Count);
+                        //Debug.Log("Stock After: " + _stockIn.Count);
 
 
-                        Debug.Log("Stock Before: " + _stockOutModelUpdated.Count);
+                        //Debug.Log("Stock Before: " + _stockOutModelUpdated.Count);
                         _stockOutModelUpdated = RemoveDuplicatedItems(_stockOutModelUpdated);
-                        Debug.Log("Stock After: " + _stockOutModelUpdated.Count);
+                        //Debug.Log("Stock After: " + _stockOutModelUpdated.Count);
      
                         // Delete duplicates in different list: Priority is given to those in stock
                         
@@ -280,6 +276,8 @@ namespace Scuti.UI {
 
         private void OnSecondVariantChanged(int value)
         {
+            Debug.Log("Show second options");
+
             Data.SelectOption2(secondVariant.options[value].text);
             Populate(thirdVariant, Data.GetOption3DropDowns(), 3);
 
@@ -305,7 +303,8 @@ namespace Scuti.UI {
                 {
                     secondVariant.value = secondVariant.options.FindIndex(f => f.text == secondOpt.labelOpt2);
                 }
-                thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
+                //thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
+                thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
             }
 
 
@@ -325,23 +324,62 @@ namespace Scuti.UI {
             firstVariantLabel.text = string.IsNullOrEmpty(Data.Option1) ? string.Empty : Data.Option1;
             secondVariantLabel.text = string.IsNullOrEmpty(Data.Option2) ? string.Empty : Data.Option2;
             thirdVariantLabel.text = string.IsNullOrEmpty(Data.Option3) ? string.Empty : Data.Option3;
-          
+
+            SetItemRandomAvailable();
+
+            Debug.Log("--- CONTROL 1---------------------------------");
+
+            Debug.Log("--- Select option 1: " + Data.GetCurrentSelectOption1());
+            Debug.Log("--- Select option 2: " + Data.GetCurrentSelectOption2());
+            Debug.Log("--- Select option 3: " + Data.GetCurrentSelectOption3());
+
+            Debug.Log("--- CONTROL 2---------------------------------");
             Populate(thirdVariant, Data.GetOption3DropDowns(), 3);
             Populate(secondVariant, Data.GetOption2DropDowns(), 2);
             Populate(firstVariant, Data.GetOption1DropDowns(), 1);
-
+            Debug.Log("--- CONTROL 3---------------------------------");
             _isInitalize = true;
-
+            Debug.Log("--- CONTROL 4---------------------------------");
             // Initialize dropdowns with items availables
             if (Data.GetInfoItemIn().Count > 0)
             {
-                firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt1);
-                secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt2);
-                thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
-            }
+                //int value1 = firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt1);
+                Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
+                int value1 = firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption1());
+                Debug.Log("-----VALUE 1: " + value1);
+                //int value2 = secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt2);
+                Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
+                int value2 = secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption2());
+                Debug.Log("-----VALUE 2: " + value2);
+                //Debug.Log("------------------- Select option 3: " + Data.GetCurrentSelectOption3());
+                //int value3 = thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
+                Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
+                int value3 = thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
+                Debug.Log("-----VALUE 3: " + value3);
 
+            }
+            Debug.Log("--- CONTROL 5---------------------------------");
             VariantChanged?.Invoke();
            
+        }
+
+        public void SetItemRandomAvailable()
+        {
+            StockModelUpdated stock = Data.GetInfoItemIn().Find(f => f.labelOpt3 != "null" && f.labelOpt2 != "null" && f.labelOpt1 != "null");
+            if (stock != null)
+            {
+
+                Data.SelectOption1(stock.labelOpt1);
+                Data.SelectOption2(stock.labelOpt2);
+                Data.SelectOption3(stock.labelOpt3);
+            }
+
+        }
+
+
+        public void UpdateValues()
+        {
+            OnFirstVariantChanged(firstVariant.value);
         }
 
         private void Populate(TMP_Dropdown dropdown, string[] options, int dropdownId)
@@ -381,6 +419,7 @@ namespace Scuti.UI {
                             {
                                 for (int j = 0; j < options.Length; j++)
                                 {
+                                    /// NO ESTOY TOMANDO EN CUENTA QUE EXISTE UNA TERCERA OPCION
                                     List<StockModelUpdated> stock2 = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt1 == options[i]);
                                     if (_option2OutOfStock.Count == stock2.Count)
                                     {
@@ -420,7 +459,8 @@ namespace Scuti.UI {
                             // Look in the out of stock list for the second variants of the product selected in the first variant are out of stock;
                             stockOut = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt1 == Data.GetCurrentSelectOption1());
                             StockModelUpdated stock2 = stockOut.Find(f => f.labelOpt2 == options[i]);
-                            if (stock2 != null )
+
+                            if (stock2 != null)
                             {
                                 colorOption.text = options[i];
                                 colorOption.Color = colorOpaque;
@@ -434,7 +474,26 @@ namespace Scuti.UI {
                             StockModelUpdated stock2 = stockOut.Find(f => f.labelOpt2 == options[i]);
                             List<StockModelUpdated> stock3 = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt2 == options[i]);
 
-                            if (stock2 != null && _option3OutOfStock.Count == stock3.Count)
+                           int count = 0;
+                           bool isOut = false;
+                           if (_option3OutOfStock.Count > 0 )
+                           {                               
+                               for(int k = 0; k < _option3OutOfStock.Count; k++)
+                               {
+                                   if(Data.GetInfoItemOutOfStock().Exists(f => f.labelOpt1 == Data.GetCurrentSelectOption1() &&
+                                                                                              f.labelOpt2 == options[i] &&
+                                                                                              f.labelOpt3 == _option3OutOfStock[k]))
+                                   {
+                                       Debug.Log("******* " +Data.GetCurrentSelectOption1() + " - " + options[i] + " - " + _option3OutOfStock[k]);
+                                       count++;
+                                   }
+                               }
+                           }
+                           if (count == _option3OutOfStock.Count)
+                               isOut = true;
+
+
+                            if (stock2 != null && /*_option3OutOfStock.Count == stock3.Count*/ isOut)
                             {
                                 colorOption.text = options[i];
                                 colorOption.Color = colorOpaque;
@@ -449,25 +508,36 @@ namespace Scuti.UI {
                     {
                         Debug.Log("Option " + i + ": " + options[i]);
 
+                        Debug.Log("Option 1 Selected: " + Data.GetCurrentSelectOption1());
+                        Debug.Log("Option 2 Selected: " + Data.GetCurrentSelectOption2());
+                       
+
+
                         ColorOptionDataTMP colorOption = new ColorOptionDataTMP(options[i], colorLight, true);
 
                         stockOut = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
+                        //stockOut = allOutOfStock.FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
                         StockModelUpdated stock3 = stockOut.Find(f => f.labelOpt3 == options[i]);
                         if (stock3 != null)
                         {
+                            Debug.Log("This option: " + options[i] + " is Disable");
                             colorOption.text = options[i];
                             colorOption.Color = colorOpaque;
                             colorOption.Interactable = false;
+                        }
+                        else 
+                        {
+                            Debug.Log("This option: " + options[i] + " is AVAILABLE");
                         }
 
                         optionsColor.Add(colorOption);
                     }
                 }
-
                 dropdown.AddOptions(new List<TMP_Dropdown.OptionData>(optionsColor));
             }
 
             dropdown.RefreshShownValue();
+;
         }
     }
 }

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -29,7 +29,10 @@ namespace Scuti.UI {
 
             private List<StockModelUpdated> _stockOutModelUpdated;
             private List<StockModelUpdated> _stockIn;
-            
+
+            private List<StockModelUpdated> distinctOut;
+            private List<StockModelUpdated> distinctIn;
+
             public int Quantity;
             public ProductVariant[] Variants
             {
@@ -108,35 +111,17 @@ namespace Scuti.UI {
                             //}
                         }
 
+                        Debug.Log("Stock Before: " + _stockIn.Count);
+                        _stockIn = RemoveDuplicatedItems(_stockIn);
+                        Debug.Log("Stock After: " + _stockIn.Count);
 
-                        // Delete duplicates in same list: Out Stock
-                        for (int j = 0; j < _stockOutModelUpdated.Count; j++)
-                        {
-                            int index = _stockOutModelUpdated.FindIndex(f => f.labelOpt1 == _stockOutModelUpdated[j].labelOpt1 &&
-                                                                            f.labelOpt2 == _stockOutModelUpdated[j].labelOpt2 &&
-                                                                            f.labelOpt3 == _stockOutModelUpdated[j].labelOpt3);
 
-                            if (index >= 0)
-                            {
-                                _stockOutModelUpdated.RemoveAt(index);
-                            }
-                        }
-
-                        // Delete duplicates in same list. In stock
-                        for (int j = 0; j < _stockIn.Count; j++)
-                        {
-                            int index = _stockIn.FindIndex(f => f.labelOpt1 == _stockIn[j].labelOpt1 &&
-                                                                            f.labelOpt2 == _stockIn[j].labelOpt2 &&
-                                                                            f.labelOpt3 == _stockIn[j].labelOpt3);
-
-                            if (index >= 0)
-                            {
-                                _stockIn.RemoveAt(index);
-                            }
-                        }
-
+                        Debug.Log("Stock Before: " + _stockOutModelUpdated.Count);
+                        _stockOutModelUpdated = RemoveDuplicatedItems(_stockOutModelUpdated);
+                        Debug.Log("Stock After: " + _stockOutModelUpdated.Count);
+     
                         // Delete duplicates in different list: Priority is given to those in stock
-
+                        
                         for (int j = 0; j < _stockIn.Count; j++)
                         {
                             int index = _stockOutModelUpdated.FindIndex(f => f.labelOpt1 == _stockIn[j].labelOpt1 &&
@@ -147,13 +132,29 @@ namespace Scuti.UI {
                             {
                                 _stockOutModelUpdated.RemoveAt(index);
                             }
-                        }
-
-
-
+                        }    
 
                     }
                 }
+            }
+
+
+            private List<StockModelUpdated> RemoveDuplicatedItems(List<StockModelUpdated> list)
+            {
+                List<StockModelUpdated> tempList = new List<StockModelUpdated>();
+
+                foreach (StockModelUpdated u1 in list)
+                {
+                    bool duplicatefound = false;
+                    foreach (StockModelUpdated u2 in tempList)
+                        if (u1.labelOpt1 == u2.labelOpt1 && u1.labelOpt2 == u2.labelOpt2 && u1.labelOpt3 == u2.labelOpt3)
+                            duplicatefound = true;
+
+                    if (!duplicatefound)
+                        tempList.Add(u1);
+                }
+
+                return tempList;
             }
 
             public string Option1;

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -25,7 +25,7 @@ namespace Scuti.UI {
         [Serializable]
         public class Model : Presenter.Model {
 
-            public static string DEFAULT = "null";
+            public static string DEFAULT = String.Empty;
 
             private List<StockModelUpdated> _stockOutModelUpdated;
             private List<StockModelUpdated> _stockIn;
@@ -52,9 +52,9 @@ namespace Scuti.UI {
 
                             StockModelUpdated stockUpdated = new StockModelUpdated();
 
-                            string oneLabel = "null";
-                            string secondLabel = "null";
-                            string thirdLabel = "null";
+                            string oneLabel = DEFAULT;
+                            string secondLabel = DEFAULT;
+                            string thirdLabel = DEFAULT;
 
                             if (!string.IsNullOrEmpty(variant.Option1))
                             {
@@ -104,20 +104,18 @@ namespace Scuti.UI {
 
                             var finalMap = innerMap[opt2];
                             finalMap[opt3] = variant;
+
+                            //Debug.Log("-----Variant: " + variant.Option3.ToString());
+
                             //}
                         }
 
-                        //Debug.Log("Stock Before: " + _stockIn.Count);
+
                         _stockIn = RemoveDuplicatedItems(_stockIn);
-                        //Debug.Log("Stock After: " + _stockIn.Count);
-
-
-                        //Debug.Log("Stock Before: " + _stockOutModelUpdated.Count);
                         _stockOutModelUpdated = RemoveDuplicatedItems(_stockOutModelUpdated);
-                        //Debug.Log("Stock After: " + _stockOutModelUpdated.Count);
+
      
-                        // Delete duplicates in different list: Priority is given to those in stock
-                        
+                        // Delete duplicates in different list: Priority is given to those in stock                        
                         for (int j = 0; j < _stockIn.Count; j++)
                         {
                             int index = _stockOutModelUpdated.FindIndex(f => f.labelOpt1 == _stockIn[j].labelOpt1 &&
@@ -316,8 +314,33 @@ namespace Scuti.UI {
             _isInitalize = false;
             _dropdownHidden = 0;
 
-            allOutOfStock = Data.GetInfoItemOutOfStock();
-            allInStock = Data.GetInfoItemIn();
+            allOutOfStock = new List<StockModelUpdated>(Data.GetInfoItemOutOfStock());
+            allInStock = new List<StockModelUpdated>(Data.GetInfoItemIn());
+
+
+            List<StockModelUpdated> auxOut = new List<StockModelUpdated>();
+            for(int i = 0; i < allOutOfStock.Count; i++)
+            {
+                if(allOutOfStock[i].labelOpt3 != Model.DEFAULT && allOutOfStock[i].labelOpt2 != Model.DEFAULT && allOutOfStock[i].labelOpt1 != Model.DEFAULT)
+                {
+                    auxOut.Add(allOutOfStock[i]);
+                }
+            }
+            allOutOfStock.Clear();
+            allOutOfStock = new List<StockModelUpdated>(auxOut);
+
+
+            List<StockModelUpdated> auxInt = new List<StockModelUpdated>();
+            for (int i = 0; i < allInStock.Count; i++)
+            {
+                if (allInStock[i].labelOpt3 != Model.DEFAULT && allInStock[i].labelOpt2 != Model.DEFAULT && allInStock[i].labelOpt1 != Model.DEFAULT)
+                {
+                    auxInt.Add(allInStock[i]);
+                }
+            }
+            allInStock.Clear();
+            allInStock = new List<StockModelUpdated>(auxInt);
+
 
             quantityStepper.Value = Data.Quantity;
 
@@ -333,47 +356,45 @@ namespace Scuti.UI {
             Debug.Log("--- Select option 2: " + Data.GetCurrentSelectOption2());
             Debug.Log("--- Select option 3: " + Data.GetCurrentSelectOption3());
 
-            Debug.Log("--- CONTROL 2---------------------------------");
+            //Debug.Log("--- CONTROL 2---------------------------------");
             Populate(thirdVariant, Data.GetOption3DropDowns(), 3);
             Populate(secondVariant, Data.GetOption2DropDowns(), 2);
             Populate(firstVariant, Data.GetOption1DropDowns(), 1);
-            Debug.Log("--- CONTROL 3---------------------------------");
+            //Debug.Log("--- CONTROL 3---------------------------------");
             _isInitalize = true;
-            Debug.Log("--- CONTROL 4---------------------------------");
+           //Debug.Log("--- CONTROL 4---------------------------------");
             // Initialize dropdowns with items availables
-            if (Data.GetInfoItemIn().Count > 0)
+            if (allInStock.Count > 0)
             {
                 //int value1 = firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt1);
-                Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
+                Debug.Log("------------------- Select option 1 STAR: " + Data.GetCurrentSelectOption1());
                 int value1 = firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption1());
                 Debug.Log("-----VALUE 1: " + value1);
                 //int value2 = secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt2);
-                Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
+                //Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
                 int value2 = secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption2());
-                Debug.Log("-----VALUE 2: " + value2);
+                //Debug.Log("-----VALUE 2: " + value2);
                 //Debug.Log("------------------- Select option 3: " + Data.GetCurrentSelectOption3());
                 //int value3 = thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
-                Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
+                //Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
                 int value3 = thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
-                Debug.Log("-----VALUE 3: " + value3);
+                //Debug.Log("-----VALUE 3: " + value3);
 
             }
-            Debug.Log("--- CONTROL 5---------------------------------");
+           // Debug.Log("--- CONTROL 5---------------------------------");
             VariantChanged?.Invoke();
            
         }
 
         public void SetItemRandomAvailable()
         {
-            StockModelUpdated stock = Data.GetInfoItemIn().Find(f => f.labelOpt3 != "null" && f.labelOpt2 != "null" && f.labelOpt1 != "null");
+            StockModelUpdated stock = allInStock.Find(f => f.labelOpt3 != Model.DEFAULT && f.labelOpt2 != Model.DEFAULT && f.labelOpt1 != Model.DEFAULT);
             if (stock != null)
             {
-
                 Data.SelectOption1(stock.labelOpt1);
                 Data.SelectOption2(stock.labelOpt2);
                 Data.SelectOption3(stock.labelOpt3);
             }
-
         }
 
 
@@ -384,7 +405,10 @@ namespace Scuti.UI {
 
         private void Populate(TMP_Dropdown dropdown, string[] options, int dropdownId)
         {
-            if(dropdownId == 3)
+            // Delete entrace null or empty
+            options = options.Where(val => val != Model.DEFAULT).ToArray();
+
+            if (dropdownId == 3)
             {
                 _option3OutOfStock = new List<string>(options);
             }
@@ -412,7 +436,57 @@ namespace Scuti.UI {
                     if (dropdownId == 1)
                     {
                         ColorOptionDataTMP colorOption = new ColorOptionDataTMP(options[i], colorLight, true);
-                        if (_dropdownHidden <= 1)
+                        if (_dropdownHidden == 0)
+                        {
+                            if (_option2OutOfStock.Count > 0 && _option3OutOfStock.Count > 0)
+                            {
+                                for (int j = 0; j < options.Length; j++)
+                                {
+                                    /// NO ESTOY TOMANDO EN CUENTA QUE EXISTE UNA TERCERA OPCION
+                                    List<StockModelUpdated> stock = allOutOfStock.FindAll(f => f.labelOpt1 == options[i]);
+                                    //Debug.Log("LISTA OPCIONES 1: " + stock.Count+ " - "+ "options: "+ options[i]);
+                                    List<StockModelUpdated> stock2 = new List<StockModelUpdated>();
+                                    int count3 = 0;
+                                    int count2 = 0;
+                                    int countAux = 0;
+                                    // Busco todos los de la lista previa pero con el segundod dropdown
+                                    for (int t = 0; t < _option2OutOfStock.Count; t++)
+                                    {
+                                        stock2.AddRange(stock.FindAll(f => f.labelOpt2 == _option2OutOfStock[t]));
+                                        // Detecto si se sumo algo nuevo a la lista. Entonces encontró coincidencias.
+                                        if (countAux < stock2.Count)
+                                        {
+                                            countAux = stock2.Count;
+                                            count2++;
+                                        }
+                                    }
+
+                                    //Debug.Log("LISTA OPCIONES 2: " + stock2.Count);
+                                    // Busco ya en la nueva lista si estan todos las opciones 3
+                                    for (int k = 0; k < _option2OutOfStock.Count; k++)
+                                    {
+                                        List<StockModelUpdated> stock3 = stock2.FindAll(f => f.labelOpt2 == _option2OutOfStock[k]);
+
+                                        if (stock3.Count == _option3OutOfStock.Count)
+                                        {
+                                            count3++;
+                                        }
+                                    }
+
+                                    if (_option2OutOfStock.Count == count2 && count3 == _option3OutOfStock.Count)
+                                    {
+                                        colorOption.text = options[i];
+                                        colorOption.Color = colorOpaque;
+                                        colorOption.Interactable = false;
+                                        break;
+                                    }
+
+                                }
+                            }
+
+
+                        }
+                        else if (_dropdownHidden == 1)
                         {
                             // Look in the out of stock list if all the variants of the second option are out of stock.
                             if (_option2OutOfStock.Count > 0)
@@ -420,7 +494,7 @@ namespace Scuti.UI {
                                 for (int j = 0; j < options.Length; j++)
                                 {
                                     /// NO ESTOY TOMANDO EN CUENTA QUE EXISTE UNA TERCERA OPCION
-                                    List<StockModelUpdated> stock2 = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt1 == options[i]);
+                                    List<StockModelUpdated> stock2 = allOutOfStock.FindAll(f => f.labelOpt1 == options[i]);
                                     if (_option2OutOfStock.Count == stock2.Count)
                                     {
                                         colorOption.text = options[i];
@@ -437,7 +511,7 @@ namespace Scuti.UI {
                         {
                             for (int j = 0; j < options.Length; j++)
                             {
-                                StockModelUpdated stock2 = Data.GetInfoItemOutOfStock().Find(f => f.labelOpt1 == options[i]);
+                                StockModelUpdated stock2 = allOutOfStock.Find(f => f.labelOpt1 == options[i]);
                                 if (stock2 != null)
                                 {
                                     colorOption.text = options[i];
@@ -457,7 +531,7 @@ namespace Scuti.UI {
                         if (_dropdownHidden == 1)
                         { 
                             // Look in the out of stock list for the second variants of the product selected in the first variant are out of stock;
-                            stockOut = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt1 == Data.GetCurrentSelectOption1());
+                            stockOut = allOutOfStock.FindAll(f => f.labelOpt1 == Data.GetCurrentSelectOption1());
                             StockModelUpdated stock2 = stockOut.Find(f => f.labelOpt2 == options[i]);
 
                             if (stock2 != null)
@@ -470,9 +544,9 @@ namespace Scuti.UI {
                         else if(_dropdownHidden == 0)
                         {
                             // Look in the out of stock list for the second variants of the product selected in the first variant are out of stock;
-                            stockOut = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt1 == Data.GetCurrentSelectOption1());
+                            stockOut = allOutOfStock.FindAll(f => f.labelOpt1 == Data.GetCurrentSelectOption1());
                             StockModelUpdated stock2 = stockOut.Find(f => f.labelOpt2 == options[i]);
-                            List<StockModelUpdated> stock3 = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt2 == options[i]);
+                            List<StockModelUpdated> stock3 = allOutOfStock.FindAll(f => f.labelOpt2 == options[i]);
 
                            int count = 0;
                            bool isOut = false;
@@ -480,11 +554,11 @@ namespace Scuti.UI {
                            {                               
                                for(int k = 0; k < _option3OutOfStock.Count; k++)
                                {
-                                   if(Data.GetInfoItemOutOfStock().Exists(f => f.labelOpt1 == Data.GetCurrentSelectOption1() &&
+                                   if(allOutOfStock.Exists(f => f.labelOpt1 == Data.GetCurrentSelectOption1() &&
                                                                                               f.labelOpt2 == options[i] &&
                                                                                               f.labelOpt3 == _option3OutOfStock[k]))
                                    {
-                                       Debug.Log("******* " +Data.GetCurrentSelectOption1() + " - " + options[i] + " - " + _option3OutOfStock[k]);
+                                      // Debug.Log("******* " +Data.GetCurrentSelectOption1() + " - " + options[i] + " - " + _option3OutOfStock[k]);
                                        count++;
                                    }
                                }
@@ -506,16 +580,12 @@ namespace Scuti.UI {
 
                     if (dropdownId == 3)
                     {
-                        Debug.Log("Option " + i + ": " + options[i]);
 
-                        Debug.Log("Option 1 Selected: " + Data.GetCurrentSelectOption1());
-                        Debug.Log("Option 2 Selected: " + Data.GetCurrentSelectOption2());
-                       
-
+                        Debug.Log("--- Option 1: " + Data.GetCurrentSelectOption1() + " Option 2: "+ Data.GetCurrentSelectOption2());
 
                         ColorOptionDataTMP colorOption = new ColorOptionDataTMP(options[i], colorLight, true);
 
-                        stockOut = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
+                        stockOut = allOutOfStock.FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
                         //stockOut = allOutOfStock.FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
                         StockModelUpdated stock3 = stockOut.Find(f => f.labelOpt3 == options[i]);
                         if (stock3 != null)

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -25,7 +25,7 @@ namespace Scuti.UI {
         [Serializable]
         public class Model : Presenter.Model {
 
-            public static string DEFAULT = "null";
+            public static string DEFAULT = "Other";
 
             private List<StockModelUpdated> _stockOutModelUpdated;
             private List<StockModelUpdated> _stockIn;
@@ -60,8 +60,12 @@ namespace Scuti.UI {
                                 {
                                     secondLabel = variant.Option2;
                                     if (!string.IsNullOrEmpty(variant.Option3))
-                                    {
+                                    {    
                                         thirdLabel = variant.Option3;
+                                    }
+                                    else 
+                                    {
+                                        Debug.Log("Is emty Label 3-" + variant.Option3+"--");
                                     }
                                 }
                             }
@@ -78,6 +82,7 @@ namespace Scuti.UI {
                             {
                                 _stockIn.Add(stockUpdated);
                             }
+                             
 
                             var opt1 = (string.IsNullOrEmpty(variant.Option1)) ? DEFAULT : variant.Option1;
                             var opt2 = (string.IsNullOrEmpty(variant.Option2)) ? DEFAULT : variant.Option2;
@@ -101,7 +106,51 @@ namespace Scuti.UI {
                             var finalMap = innerMap[opt2];
                             finalMap[opt3] = variant;
                             //}
-                        } 
+                        }
+
+
+                        // Delete duplicates in same list: Out Stock
+                        for (int j = 0; j < _stockOutModelUpdated.Count; j++)
+                        {
+                            int index = _stockOutModelUpdated.FindIndex(f => f.labelOpt1 == _stockOutModelUpdated[j].labelOpt1 &&
+                                                                            f.labelOpt2 == _stockOutModelUpdated[j].labelOpt2 &&
+                                                                            f.labelOpt3 == _stockOutModelUpdated[j].labelOpt3);
+
+                            if (index >= 0)
+                            {
+                                _stockOutModelUpdated.RemoveAt(index);
+                            }
+                        }
+
+                        // Delete duplicates in same list. In stock
+                        for (int j = 0; j < _stockIn.Count; j++)
+                        {
+                            int index = _stockIn.FindIndex(f => f.labelOpt1 == _stockIn[j].labelOpt1 &&
+                                                                            f.labelOpt2 == _stockIn[j].labelOpt2 &&
+                                                                            f.labelOpt3 == _stockIn[j].labelOpt3);
+
+                            if (index >= 0)
+                            {
+                                _stockIn.RemoveAt(index);
+                            }
+                        }
+
+                        // Delete duplicates in different list: Priority is given to those in stock
+
+                        for (int j = 0; j < _stockIn.Count; j++)
+                        {
+                            int index = _stockOutModelUpdated.FindIndex(f => f.labelOpt1 == _stockIn[j].labelOpt1 &&
+                                                                            f.labelOpt2 == _stockIn[j].labelOpt2 &&
+                                                                            f.labelOpt3 == _stockIn[j].labelOpt3);
+
+                            if (index >= 0)
+                            {
+                                _stockOutModelUpdated.RemoveAt(index);
+                            }
+                        }
+
+
+
 
                     }
                 }
@@ -397,6 +446,8 @@ namespace Scuti.UI {
 
                     if (dropdownId == 3)
                     {
+                        Debug.Log("Option " + i + ": " + options[i]);
+
                         ColorOptionDataTMP colorOption = new ColorOptionDataTMP(options[i], colorLight, true);
 
                         stockOut = Data.GetInfoItemOutOfStock().FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -104,16 +104,12 @@ namespace Scuti.UI {
 
                             var finalMap = innerMap[opt2];
                             finalMap[opt3] = variant;
-
-                            //Debug.Log("-----Variant: " + variant.Option3.ToString());
-
                             //}
                         }
 
 
                         _stockIn = RemoveDuplicatedItems(_stockIn);
                         _stockOutModelUpdated = RemoveDuplicatedItems(_stockOutModelUpdated);
-
      
                         // Delete duplicates in different list: Priority is given to those in stock                        
                         for (int j = 0; j < _stockIn.Count; j++)
@@ -317,7 +313,8 @@ namespace Scuti.UI {
             allOutOfStock = new List<StockModelUpdated>(Data.GetInfoItemOutOfStock());
             allInStock = new List<StockModelUpdated>(Data.GetInfoItemIn());
 
-
+            // Delete products with empty or null data.
+            // For products out of stock
             List<StockModelUpdated> auxOut = new List<StockModelUpdated>();
             for(int i = 0; i < allOutOfStock.Count; i++)
             {
@@ -329,7 +326,7 @@ namespace Scuti.UI {
             allOutOfStock.Clear();
             allOutOfStock = new List<StockModelUpdated>(auxOut);
 
-
+            // For products in stock
             List<StockModelUpdated> auxInt = new List<StockModelUpdated>();
             for (int i = 0; i < allInStock.Count; i++)
             {
@@ -350,38 +347,20 @@ namespace Scuti.UI {
 
             SetItemRandomAvailable();
 
-            Debug.Log("--- CONTROL 1---------------------------------");
-
-            Debug.Log("--- Select option 1: " + Data.GetCurrentSelectOption1());
-            Debug.Log("--- Select option 2: " + Data.GetCurrentSelectOption2());
-            Debug.Log("--- Select option 3: " + Data.GetCurrentSelectOption3());
-
-            //Debug.Log("--- CONTROL 2---------------------------------");
             Populate(thirdVariant, Data.GetOption3DropDowns(), 3);
             Populate(secondVariant, Data.GetOption2DropDowns(), 2);
             Populate(firstVariant, Data.GetOption1DropDowns(), 1);
-            //Debug.Log("--- CONTROL 3---------------------------------");
+
             _isInitalize = true;
-           //Debug.Log("--- CONTROL 4---------------------------------");
+
             // Initialize dropdowns with items availables
             if (allInStock.Count > 0)
             {
-                //int value1 = firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt1);
-                Debug.Log("------------------- Select option 1 STAR: " + Data.GetCurrentSelectOption1());
-                int value1 = firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption1());
-                Debug.Log("-----VALUE 1: " + value1);
-                //int value2 = secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt2);
-                //Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
-                int value2 = secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption2());
-                //Debug.Log("-----VALUE 2: " + value2);
-                //Debug.Log("------------------- Select option 3: " + Data.GetCurrentSelectOption3());
-                //int value3 = thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
-                //Debug.Log("------------------- Select option 3 STAR: " + Data.GetCurrentSelectOption3());
-                int value3 = thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
-                //Debug.Log("-----VALUE 3: " + value3);
-
+                firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption1());
+                secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption2());
+                thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
             }
-           // Debug.Log("--- CONTROL 5---------------------------------");
+
             VariantChanged?.Invoke();
            
         }
@@ -442,18 +421,16 @@ namespace Scuti.UI {
                             {
                                 for (int j = 0; j < options.Length; j++)
                                 {
-                                    /// NO ESTOY TOMANDO EN CUENTA QUE EXISTE UNA TERCERA OPCION
                                     List<StockModelUpdated> stock = allOutOfStock.FindAll(f => f.labelOpt1 == options[i]);
-                                    //Debug.Log("LISTA OPCIONES 1: " + stock.Count+ " - "+ "options: "+ options[i]);
                                     List<StockModelUpdated> stock2 = new List<StockModelUpdated>();
                                     int count3 = 0;
                                     int count2 = 0;
                                     int countAux = 0;
-                                    // Busco todos los de la lista previa pero con el segundod dropdown
+                                    // We look for the items in the list with the specified options 1 and create a new one with all possible options 2.
                                     for (int t = 0; t < _option2OutOfStock.Count; t++)
                                     {
                                         stock2.AddRange(stock.FindAll(f => f.labelOpt2 == _option2OutOfStock[t]));
-                                        // Detecto si se sumo algo nuevo a la lista. Entonces encontró coincidencias.
+                                        // It is detected if something new is added to the list. I.e., it found matches and it is added
                                         if (countAux < stock2.Count)
                                         {
                                             countAux = stock2.Count;
@@ -461,8 +438,7 @@ namespace Scuti.UI {
                                         }
                                     }
 
-                                    //Debug.Log("LISTA OPCIONES 2: " + stock2.Count);
-                                    // Busco ya en la nueva lista si estan todos las opciones 3
+                                    // Searching in the last list if there are all possible options 3
                                     for (int k = 0; k < _option2OutOfStock.Count; k++)
                                     {
                                         List<StockModelUpdated> stock3 = stock2.FindAll(f => f.labelOpt2 == _option2OutOfStock[k]);
@@ -493,7 +469,6 @@ namespace Scuti.UI {
                             {
                                 for (int j = 0; j < options.Length; j++)
                                 {
-                                    /// NO ESTOY TOMANDO EN CUENTA QUE EXISTE UNA TERCERA OPCION
                                     List<StockModelUpdated> stock2 = allOutOfStock.FindAll(f => f.labelOpt1 == options[i]);
                                     if (_option2OutOfStock.Count == stock2.Count)
                                     {
@@ -558,7 +533,6 @@ namespace Scuti.UI {
                                                                                               f.labelOpt2 == options[i] &&
                                                                                               f.labelOpt3 == _option3OutOfStock[k]))
                                    {
-                                      // Debug.Log("******* " +Data.GetCurrentSelectOption1() + " - " + options[i] + " - " + _option3OutOfStock[k]);
                                        count++;
                                    }
                                }
@@ -567,7 +541,7 @@ namespace Scuti.UI {
                                isOut = true;
 
 
-                            if (stock2 != null && /*_option3OutOfStock.Count == stock3.Count*/ isOut)
+                            if (stock2 != null && isOut)
                             {
                                 colorOption.text = options[i];
                                 colorOption.Color = colorOpaque;
@@ -581,23 +555,15 @@ namespace Scuti.UI {
                     if (dropdownId == 3)
                     {
 
-                        Debug.Log("--- Option 1: " + Data.GetCurrentSelectOption1() + " Option 2: "+ Data.GetCurrentSelectOption2());
-
                         ColorOptionDataTMP colorOption = new ColorOptionDataTMP(options[i], colorLight, true);
 
                         stockOut = allOutOfStock.FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
-                        //stockOut = allOutOfStock.FindAll(f => f.labelOpt2 == Data.GetCurrentSelectOption2() && f.labelOpt1 == Data.GetCurrentSelectOption1());
                         StockModelUpdated stock3 = stockOut.Find(f => f.labelOpt3 == options[i]);
                         if (stock3 != null)
                         {
-                            Debug.Log("This option: " + options[i] + " is Disable");
                             colorOption.text = options[i];
                             colorOption.Color = colorOpaque;
                             colorOption.Interactable = false;
-                        }
-                        else 
-                        {
-                            Debug.Log("This option: " + options[i] + " is AVAILABLE");
                         }
 
                         optionsColor.Add(colorOption);

--- a/Scuti/Scripts/UI/Store/OfferDetailsPresenter.cs
+++ b/Scuti/Scripts/UI/Store/OfferDetailsPresenter.cs
@@ -118,7 +118,6 @@ namespace Scuti.UI
                 return;
             }
 
-
             AddToCartHelper();
             UIManager.Cart.PurchaseOnLoad(true);
             UIManager.Open(UIManager.Cart);

--- a/Scuti/UI/Prefabs/Store/Offer Details Panel.prefab
+++ b/Scuti/UI/Prefabs/Store/Offer Details Panel.prefab
@@ -4816,6 +4816,7 @@ GameObject:
   - component: {fileID: 114114617320867376}
   - component: {fileID: 8518362457808678468}
   - component: {fileID: 1511556636737843572}
+  - component: {fileID: 982667970357495514}
   m_Layer: 5
   m_Name: Variant
   m_TagString: Untagged
@@ -4962,6 +4963,35 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &982667970357495514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1440335506984046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1862395651, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 4
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 114471161576252040}
+          m_MethodName: UpdateValues
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  delegates: []
 --- !u!1 &1443596961216306
 GameObject:
   m_ObjectHideFlags: 0
@@ -16135,12 +16165,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 066a8441b61db3844ac8ce3a28719c69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3622910922094991271 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4007321775438007249, guid: d091a947fa60223469d232ccf88d76f3,
-    type: 3}
-  m_PrefabInstance: {fileID: 422203280982105206}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1005703453819430251 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 589705829406161181, guid: d091a947fa60223469d232ccf88d76f3,
@@ -16162,6 +16186,12 @@ GameObject:
 --- !u!224 &4831007310820864014 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5102816044208860280, guid: d091a947fa60223469d232ccf88d76f3,
+    type: 3}
+  m_PrefabInstance: {fileID: 422203280982105206}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &3622910922094991271 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4007321775438007249, guid: d091a947fa60223469d232ccf88d76f3,
     type: 3}
   m_PrefabInstance: {fileID: 422203280982105206}
   m_PrefabAsset: {fileID: 0}
@@ -16466,15 +16496,15 @@ MonoBehaviour:
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2015649091822024912 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3816486990427245664, guid: 021f2a4c9ddc03c419635f9c4bd07ed2,
-    type: 3}
-  m_PrefabInstance: {fileID: 3391180390612022448}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &7689056264465407865 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5024582829128870857, guid: 021f2a4c9ddc03c419635f9c4bd07ed2,
+    type: 3}
+  m_PrefabInstance: {fileID: 3391180390612022448}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2015649091822024912 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3816486990427245664, guid: 021f2a4c9ddc03c419635f9c4bd07ed2,
     type: 3}
   m_PrefabInstance: {fileID: 3391180390612022448}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
- Fixed error of loading card data when entering the cart (saving the card in this instance).
- Added code to remove duplicate products in the list that is in stock.
- Added code to prioritize products in stock when there are duplicate products.
- Fixed bug that showed deactivated product variants when they existed, and vice versa.
- Fixed bug when arriving null or empty variants.