### PR TITLE
Disable out of stock items

### DIFF
--- a/Scuti/Resources/Materials/RoundedBanner.mat
+++ b/Scuti/Resources/Materials/RoundedBanner.mat
@@ -82,4 +82,4 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _WidthHeightRadius: {r: 889.6699, g: 0, b: 50, a: 0}
+    - _WidthHeightRadius: {r: 889.6699, g: 111.20874, b: 50, a: 0}

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -17,9 +17,15 @@ namespace Scuti.UI {
         [Serializable]
         public class StockModelUpdated
         {
+            [SerializeField] public string name;
             [SerializeField] public string labelOpt1;
             [SerializeField] public string labelOpt2;
             [SerializeField] public string labelOpt3;
+
+            public void SetName()
+            {
+                name = labelOpt1 +" - "+ labelOpt2 +" - "+ labelOpt3;
+            }
         }
 
         [Serializable]
@@ -107,6 +113,8 @@ namespace Scuti.UI {
                             //}
                         }
 
+                        Debug.Log("_inStock: "+_stockIn.Count);
+                        Debug.Log("_outStock: " + _stockOutModelUpdated.Count);
 
                         _stockIn = RemoveDuplicatedItems(_stockIn);
                         _stockOutModelUpdated = RemoveDuplicatedItems(_stockOutModelUpdated);
@@ -275,7 +283,7 @@ namespace Scuti.UI {
             Data.SelectOption2(secondVariant.options[value].text);
             Populate(thirdVariant, Data.GetOption3DropDowns(), 3);
 
-            if (Data.GetInfoItemIn().Count > 0)
+            if (allInStock.Count > 0)
             {
                 var thirdOpt = allInStock.Find(f => f.labelOpt2 == secondVariant.options[value].text);
                 thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == thirdOpt.labelOpt3);
@@ -292,13 +300,13 @@ namespace Scuti.UI {
             Populate(secondVariant, Data.GetOption2DropDowns(), 2);
             Populate(thirdVariant, Data.GetOption3DropDowns(), 3);
 
-            if (Data.GetInfoItemIn().Count > 0)
+            if (allInStock.Count > 0)
             {
                 var secondOpt = allInStock.Find(f => f.labelOpt1 == firstVariant.options[value].text);
                 if(secondOpt != null)
                 {
                     secondVariant.value = secondVariant.options.FindIndex(f => f.text == secondOpt.labelOpt2);
-                }
+                }              
                 //thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetInfoItemIn()[0].labelOpt3);
                 thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
             }
@@ -315,16 +323,69 @@ namespace Scuti.UI {
             allOutOfStock = new List<StockModelUpdated>(Data.GetInfoItemOutOfStock());
             allInStock = new List<StockModelUpdated>(Data.GetInfoItemIn());
 
+            #region Detect dropdown options amount
+            int count1 = 0;
+            int count2 = 0;
+            int count3 = 0;
+            //Detect if there is at least one valid option for each dropdown
+            for (int i = 0; i < Data.GetOption3DropDowns().Length; i++)
+            {
+                if (Data.GetOption3DropDowns()[i] != Model.DEFAULT)
+                {
+                    count3++;
+                }
+            }
+
+            for (int i = 0; i < Data.GetOption2DropDowns().Length; i++)
+            {
+                if (Data.GetOption2DropDowns()[i] != Model.DEFAULT)
+                {
+                    count2++;
+                }
+            }
+
+            for (int i = 0; i < Data.GetOption1DropDowns().Length; i++)
+            {
+                if (Data.GetOption1DropDowns()[i] != Model.DEFAULT)
+                {
+                    count1++;
+                }
+            }
+            #endregion
+
             // Delete products with empty or null data.
             // For products out of stock
             List<StockModelUpdated> auxOut = new List<StockModelUpdated>();
-            for(int i = 0; i < allOutOfStock.Count; i++)
+            for (int i = 0; i < allOutOfStock.Count; i++)
             {
-                if(allOutOfStock[i].labelOpt3 != Model.DEFAULT && allOutOfStock[i].labelOpt2 != Model.DEFAULT && allOutOfStock[i].labelOpt1 != Model.DEFAULT)
+
+                if (count3 <= 0 && count2 <= 0)
                 {
-                    auxOut.Add(allOutOfStock[i]);
+                    if (allOutOfStock[i].labelOpt1 != Model.DEFAULT)
+                    {
+                        allOutOfStock[i].SetName();
+                        auxOut.Add(allOutOfStock[i]);
+                    }
                 }
+                else if (count3 <= 0 && count2 > 0)
+                {
+                    if (allOutOfStock[i].labelOpt2 != Model.DEFAULT && allOutOfStock[i].labelOpt1 != Model.DEFAULT)
+                    {
+                        allOutOfStock[i].SetName();
+                        auxOut.Add(allOutOfStock[i]);
+                    }
+                }
+                else 
+                {
+                    if (allOutOfStock[i].labelOpt3 != Model.DEFAULT && allOutOfStock[i].labelOpt2 != Model.DEFAULT && allOutOfStock[i].labelOpt1 != Model.DEFAULT)
+                    {
+                        allOutOfStock[i].SetName();
+                        auxOut.Add(allOutOfStock[i]);
+                    }
+                }
+
             }
+
             allOutOfStock.Clear();
             allOutOfStock = new List<StockModelUpdated>(auxOut);
 
@@ -332,14 +393,35 @@ namespace Scuti.UI {
             List<StockModelUpdated> auxInt = new List<StockModelUpdated>();
             for (int i = 0; i < allInStock.Count; i++)
             {
-                if (allInStock[i].labelOpt3 != Model.DEFAULT && allInStock[i].labelOpt2 != Model.DEFAULT && allInStock[i].labelOpt1 != Model.DEFAULT)
+
+                if (count3 <= 0 && count2 <= 0)
                 {
-                    auxInt.Add(allInStock[i]);
+                    if (allInStock[i].labelOpt1 != Model.DEFAULT)
+                    {
+                        allInStock[i].SetName();
+                        auxInt.Add(allInStock[i]);
+                    }
                 }
+                else if(count3 <= 0)
+                {
+                    if (allInStock[i].labelOpt2 != Model.DEFAULT && allInStock[i].labelOpt1 != Model.DEFAULT)
+                    {
+                        allInStock[i].SetName();
+                        auxInt.Add(allInStock[i]);
+                    }
+                }
+                else
+                {
+                    if (allInStock[i].labelOpt3 != Model.DEFAULT && allInStock[i].labelOpt2 != Model.DEFAULT && allInStock[i].labelOpt1 != Model.DEFAULT)
+                    {
+                        allInStock[i].SetName();
+                        auxInt.Add(allInStock[i]);
+                    }
+                }
+
             }
             allInStock.Clear();
             allInStock = new List<StockModelUpdated>(auxInt);
-
 
             quantityStepper.Value = Data.Quantity;
 
@@ -361,6 +443,12 @@ namespace Scuti.UI {
                 firstVariant.value = firstVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption1());
                 secondVariant.value = secondVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption2());
                 thirdVariant.value = thirdVariant.options.FindIndex(f => f.text == Data.GetCurrentSelectOption3());
+            }
+
+            // Set initial option with just one dropdown active
+            if (_dropdownHidden == 2)
+            {
+                firstVariant.value = firstVariant.options.FindIndex(f => f.text == allInStock[0].labelOpt1);
             }
 
             VariantChanged?.Invoke();
@@ -487,15 +575,16 @@ namespace Scuti.UI {
                         else if(_dropdownHidden == 2)
                         {
                             for (int j = 0; j < options.Length; j++)
-                            {
-                                StockModelUpdated stock2 = allOutOfStock.Find(f => f.labelOpt1 == options[i]);
-                                if (stock2 != null)
+                            {  
+                                StockModelUpdated stock = allOutOfStock.Find(f => f.labelOpt1 == options[i]);
+                                if (stock != null)
                                 {
                                     colorOption.text = options[i];
                                     colorOption.Color = colorOpaque;
                                     colorOption.Interactable = false;
                                     break;
-                                }
+                                }      
+
                             }
                         }
 

--- a/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
+++ b/Scuti/Scripts/UI/Store/Offer Details/OfferCustomizationPresenter.cs
@@ -324,42 +324,50 @@ namespace Scuti.UI {
             allInStock = new List<StockModelUpdated>(Data.GetInfoItemIn());
 
             #region Detect dropdown options amount
-            int count1 = 0;
-            int count2 = 0;
-            int count3 = 0;
+            int aux = 0;
+            int countDropdown = 0;
+
             //Detect if there is at least one valid option for each dropdown
             for (int i = 0; i < Data.GetOption3DropDowns().Length; i++)
             {
-                if (Data.GetOption3DropDowns()[i] != Model.DEFAULT)
-                {
-                    count3++;
-                }
+                if (Data.GetOption3DropDowns()[i] != Model.DEFAULT) aux++;  
             }
+
+            if (aux > 0)
+            {
+                countDropdown++;
+                aux = 0;
+            }            
 
             for (int i = 0; i < Data.GetOption2DropDowns().Length; i++)
             {
-                if (Data.GetOption2DropDowns()[i] != Model.DEFAULT)
-                {
-                    count2++;
-                }
+                if (Data.GetOption2DropDowns()[i] != Model.DEFAULT) aux++;
+            }
+
+            if (aux > 0)
+            {
+                countDropdown++;
+                aux = 0;
             }
 
             for (int i = 0; i < Data.GetOption1DropDowns().Length; i++)
             {
-                if (Data.GetOption1DropDowns()[i] != Model.DEFAULT)
-                {
-                    count1++;
-                }
+                if (Data.GetOption1DropDowns()[i] != Model.DEFAULT) aux++;
             }
+
+            if (aux > 0) countDropdown++;
+
             #endregion
 
-            // Delete products with empty or null data.
+
+            #region Delete products with empty or null data.
+
             // For products out of stock
             List<StockModelUpdated> auxOut = new List<StockModelUpdated>();
             for (int i = 0; i < allOutOfStock.Count; i++)
             {
 
-                if (count3 <= 0 && count2 <= 0)
+                if (countDropdown == 1)
                 {
                     if (allOutOfStock[i].labelOpt1 != Model.DEFAULT)
                     {
@@ -367,7 +375,7 @@ namespace Scuti.UI {
                         auxOut.Add(allOutOfStock[i]);
                     }
                 }
-                else if (count3 <= 0 && count2 > 0)
+                else if (countDropdown == 2)
                 {
                     if (allOutOfStock[i].labelOpt2 != Model.DEFAULT && allOutOfStock[i].labelOpt1 != Model.DEFAULT)
                     {
@@ -394,7 +402,7 @@ namespace Scuti.UI {
             for (int i = 0; i < allInStock.Count; i++)
             {
 
-                if (count3 <= 0 && count2 <= 0)
+                if (countDropdown == 1)
                 {
                     if (allInStock[i].labelOpt1 != Model.DEFAULT)
                     {
@@ -402,7 +410,7 @@ namespace Scuti.UI {
                         auxInt.Add(allInStock[i]);
                     }
                 }
-                else if(count3 <= 0)
+                else if(countDropdown == 2)
                 {
                     if (allInStock[i].labelOpt2 != Model.DEFAULT && allInStock[i].labelOpt1 != Model.DEFAULT)
                     {
@@ -420,9 +428,11 @@ namespace Scuti.UI {
                 }
 
             }
+           
             allInStock.Clear();
             allInStock = new List<StockModelUpdated>(auxInt);
 
+            #endregion
             quantityStepper.Value = Data.Quantity;
 
             firstVariantLabel.text = string.IsNullOrEmpty(Data.Option1) ? string.Empty : Data.Option1;


### PR DESCRIPTION
- Fixed problem that when entering a product with only one dropdown (size for example) the products out of stock were not updated correctly.

- Fixed problem that did not initially select a product from stock (only with an active dropdown).