### PR TITLE
Remove callbacks from the Wallet Widget after destroy

### DIFF
--- a/Scuti/Scripts/UI/Account/WalletWidget.cs
+++ b/Scuti/Scripts/UI/Account/WalletWidget.cs
@@ -22,6 +22,11 @@ public class WalletWidget : MonoBehaviour {
 #pragma warning restore 4014
     }
 
+    private void OnDestroy()
+    {
+        ScutiAPI.OnWalletUpdated -= OnWalletUpdated;
+        ScutiNetClient.Instance.OnAuthenticated -= DoRefresh;
+    }
 
     private void OnWalletUpdated(int balance)
     { 


### PR DESCRIPTION
Remove the callbacks from the wallet widget after destroy, they were not being cleaned 